### PR TITLE
Various fixes + compatibility with MacOS 26 + updated color handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 ## User settings
 xcuserdata/
 
+# Xcode nonsense
+*.pbxproj
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout

--- a/Pulse/Components/Browser/Window/WindowBackgroundView.swift
+++ b/Pulse/Components/Browser/Window/WindowBackgroundView.swift
@@ -22,6 +22,7 @@ struct WindowBackgroundView: View {
             if #available(macOS 26.0, *) {
                 Rectangle()
                     .fill(Color.clear)
+                    .blur(radius: 40)
                     .glassEffect(in: .rect(cornerRadius: 0))
             } else {
                 BlurEffectView(material: .hudWindow, state: .active)
@@ -35,9 +36,24 @@ struct WindowBackgroundView: View {
 #if DEBUG
 struct WindowBackgroundView_Previews: PreviewProvider {
     static var previews: some View {
-        WindowBackgroundView()
-            .frame(width: 300, height: 200)
-            .previewLayout(.sizeThatFits)
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [.blue, .green]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            WindowBackgroundView()
+                .padding()
+            
+            Text("hi there")
+                .font(.custom("SF Pro", size: 20))
+                .foregroundColor(.gray)
+        }
+        .frame(width: 300, height: 200)
+        .previewLayout(.sizeThatFits)
     }
 }
 #endif
+

--- a/Pulse/Components/Browser/Window/WindowBackgroundView.swift
+++ b/Pulse/Components/Browser/Window/WindowBackgroundView.swift
@@ -18,9 +18,26 @@ struct WindowBackgroundView: View {
     }
 
     var body: some View {
-        ZStack {
-            BlurEffectView(material: .hudWindow, state: .active)
+        Group {
+            if #available(macOS 26.0, *) {
+                Rectangle()
+                    .fill(Color.clear)
+                    .glassEffect(in: .rect(cornerRadius: 0))
+            } else {
+                BlurEffectView(material: .hudWindow, state: .active)
+            }
         }
         .gesture(dragWindow)
     }
 }
+
+
+#if DEBUG
+struct WindowBackgroundView_Previews: PreviewProvider {
+    static var previews: some View {
+        WindowBackgroundView()
+            .frame(width: 300, height: 200)
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Pulse/Components/Sidebar/NavButtons/NavButton.swift
+++ b/Pulse/Components/Sidebar/NavButtons/NavButton.swift
@@ -25,7 +25,7 @@ struct NavButton: View {
         } label: {
             Image(systemName: iconName)
                 .font(.system(size: 16))
-                .foregroundStyle(disabled ? .white.opacity(0.2) : .white.opacity(0.4))
+                .foregroundStyle(disabled ? AppColors.textQuaternary : AppColors.textSecondary)
                 .padding(4)
                 .contentTransition(.symbolEffect(.replace.upUp.byLayer, options: .nonRepeating))
         }
@@ -33,7 +33,7 @@ struct NavButton: View {
         .disabled(disabled)
         .background(
             RoundedRectangle(cornerRadius: 6)
-                .fill(Color.white.opacity(isHovering && !disabled ? 0.2 : 0))
+                .fill(isHovering && !disabled ? AppColors.controlBackgroundHover : Color.clear)
                 .frame(width: 24, height: 24) // Fixed 20x20 square
                 .animation(.easeInOut(duration: 0.15), value: isHovering)
         )

--- a/Pulse/Components/Sidebar/NewTabButton.swift
+++ b/Pulse/Components/Sidebar/NewTabButton.swift
@@ -20,10 +20,10 @@ struct NewTabButton: View {
                     Image(systemName: "plus")
                         .font(.system(size: 14))
                         .frame(width: 20, height: 20)
-                        .foregroundStyle(Color.white.opacity(0.3))
+                        .foregroundStyle(AppColors.textSecondary)
                     Text("New Tab")
                         .font(.system(size: 14, weight: .regular))
-                        .foregroundStyle(Color.white.opacity(0.3))
+                        .foregroundStyle(AppColors.textSecondary)
                     Spacer()
             }
             .padding(.horizontal, 10)
@@ -45,9 +45,9 @@ struct NewTabButton: View {
     
     private var backgroundColor: Color {
         if browserManager.isCommandPaletteVisible {
-            return Color.white.opacity(0.28)
+            return AppColors.controlBackgroundActive
         } else if isHovering {
-            return Color.white.opacity(0.15)
+            return AppColors.controlBackgroundHover
         } else {
             return Color.clear
         }

--- a/Pulse/Components/Sidebar/PinnedButtons/PinnedButtonView.swift
+++ b/Pulse/Components/Sidebar/PinnedButtons/PinnedButtonView.swift
@@ -25,12 +25,12 @@ struct PinnedButtonView: View {
         } label: {
             Image(systemName: iconName)
                 .font(.system(size: 16))
-                .foregroundStyle(.white.opacity(0.4))
+                .foregroundStyle(AppColors.textSecondary)
         }
         .buttonStyle(.plain)
         .padding(.vertical, 16)
         .frame(maxWidth: .infinity)
-        .background(Color.white.opacity(0.08))
+        .background(AppColors.controlBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }

--- a/Pulse/Components/Sidebar/SidebarResizeView.swift
+++ b/Pulse/Components/Sidebar/SidebarResizeView.swift
@@ -12,25 +12,17 @@ struct SidebarResizeView: View {
     @State private var isResizing = false
     @State private var isHovering = false
     @State private var startingWidth: CGFloat = 0
-    
+    @State private var startingMouseX: CGFloat = 0
+
     var body: some View {
         Rectangle()
-            .fill(Color.clear) // Invisible but interactive
-            .frame(width: 12) // Wider hit area
-            .overlay(
-                // Visual indicator
-                Rectangle()
-                    .fill(Color.clear)
-                    .frame(width: 2)
-                    .animation(.easeInOut(duration: 0.1), value: isHovering)
-            )
-            .contentShape(Rectangle()) // Ensures the entire frame is interactive
+            .fill(Color.clear)
+            .frame(width: 8)
+            .contentShape(Rectangle())
             .onHover { hovering in
                 guard browserManager.isSidebarVisible else { return }
                 
-                withAnimation(.easeInOut(duration: 0.1)) {
-                    isHovering = hovering
-                }
+                isHovering = hovering
                 
                 if hovering && !isResizing {
                     NSCursor.resizeLeftRight.set()
@@ -39,26 +31,29 @@ struct SidebarResizeView: View {
                 }
             }
             .gesture(
-                DragGesture(minimumDistance: 0)
+                DragGesture(minimumDistance: 0, coordinateSpace: .global)
                     .onChanged { value in
                         guard browserManager.isSidebarVisible else { return }
                         
                         if !isResizing {
                             startingWidth = browserManager.sidebarWidth
+                            startingMouseX = value.startLocation.x
                             isResizing = true
-                            NSCursor.resizeLeftRight.set() // Ensure cursor stays consistent during drag
+                            NSCursor.resizeLeftRight.set()
                         }
                         
-                        let newWidth = startingWidth + value.translation.width
-                        let clampedWidth = max(100, min(300, newWidth))
+                        // Use absolute mouse positions for true 1:1 tracking
+                        let currentMouseX = value.location.x
+                        let mouseMovement = currentMouseX - startingMouseX
+                        let newWidth = startingWidth + mouseMovement
+                        let clampedWidth = max(100, min(400, newWidth))
                         
-                        // Use withAnimation(nil) to disable implicit animations during resize
-                        withAnimation(nil) {
-                            browserManager.updateSidebarWidth(clampedWidth)
-                        }
+                        browserManager.updateSidebarWidth(clampedWidth)
                     }
                     .onEnded { _ in
                         isResizing = false
+                        browserManager.saveSidebarWidthToDefaults()
+                        
                         if isHovering {
                             NSCursor.resizeLeftRight.set()
                         } else {

--- a/Pulse/Components/Sidebar/SidebarView.swift
+++ b/Pulse/Components/Sidebar/SidebarView.swift
@@ -18,7 +18,9 @@ struct SidebarView: View {
                                 .fill(Color.clear)
                                 .contentShape(Rectangle())
                                 .onTapGesture(count: 2) {
-                                    zoomCurrentWindow()
+                                    DispatchQueue.main.async {
+                                        zoomCurrentWindow()
+                                    }
                                 }
                         )
                         
@@ -39,10 +41,14 @@ struct SidebarView: View {
                                 tabIcon: tab.favicon,
                                 isActive: tab.isCurrentTab,
                                 action: {
-                                    tab.activate()
+                                    DispatchQueue.main.async {
+                                        tab.activate()
+                                    }
                                 },
                                 onClose: {
-                                    tab.closeTab()
+                                    DispatchQueue.main.async {
+                                        tab.closeTab()
+                                    }
                                 },
                             )
 

--- a/Pulse/Components/Sidebar/SidebarView.swift
+++ b/Pulse/Components/Sidebar/SidebarView.swift
@@ -5,10 +5,8 @@ struct SidebarView: View {
     @State private var draggedTabIndex: Int?
 
     var body: some View {
-        HStack(spacing: 0) {
-            if browserManager.isSidebarVisible {
-                HStack {
-                    VStack(spacing: 8) {
+        if browserManager.isSidebarVisible {
+            VStack(spacing: 8) {
                         HStack(spacing: 2) {
                             NavButtonsView()
                         }
@@ -54,14 +52,10 @@ struct SidebarView: View {
 
                         }
 
-                        Spacer()
-                    }
-                }
-                .frame(width: browserManager.sidebarWidth)
-                .padding(.top, 8)
-                .transition(.move(edge: .leading))
+                Spacer()
             }
+            .frame(width: browserManager.sidebarWidth)
+            .padding(.top, 8)
         }
-        .clipped()
     }
 }

--- a/Pulse/Components/Sidebar/SpaceSection/SpaceTab.swift
+++ b/Pulse/Components/Sidebar/SpaceSection/SpaceTab.swift
@@ -25,7 +25,7 @@ struct SpaceTab: View {
                     .frame(width: 20, height: 20)
                 Text(tabName)
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.7))
+                    .foregroundStyle(AppColors.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer()
@@ -34,9 +34,9 @@ struct SpaceTab: View {
                     Button(action: onClose) {
                         Image(systemName: "xmark")
                             .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(Color.white.opacity(0.7))
+                            .foregroundColor(AppColors.textPrimary)
                             .padding(4)
-                            .background(Color.white.opacity(0.2))
+                            .background(AppColors.controlBackgroundHover)
                             .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
                     .buttonStyle(PlainButtonStyle())
@@ -61,9 +61,9 @@ struct SpaceTab: View {
     
     private var backgroundColor: Color {
         if isActive {
-            return Color.white.opacity(0.28)
+            return AppColors.controlBackgroundActive
         } else if isHovering {
-            return Color.white.opacity(0.15)
+            return AppColors.controlBackgroundHover
         } else {
             return Color.clear
         }

--- a/Pulse/Components/Sidebar/SpaceSection/SpaceTittle.swift
+++ b/Pulse/Components/Sidebar/SpaceSection/SpaceTittle.swift
@@ -17,7 +17,7 @@ struct SpaceTittle: View {
                 .font(.system(size: 12))
             Text(spaceName)
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color.white.opacity(0.4))
+                .foregroundStyle(AppColors.textSecondary)
             Spacer()
         }
         .padding(.horizontal, 6)

--- a/Pulse/Components/Sidebar/URLBarView.swift
+++ b/Pulse/Components/Sidebar/URLBarView.swift
@@ -17,7 +17,7 @@ struct URLBarView: View {
                     displayURL
                 )
                 .font(.system(size: 12, weight: .medium, design: .default))
-                .foregroundStyle(Color.white.opacity(0.8))
+                .foregroundStyle(AppColors.textPrimary)
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -26,7 +26,7 @@ struct URLBarView: View {
             .padding(.horizontal, 12)
         }
         .frame(maxWidth: .infinity, minHeight: 36, maxHeight: 36)
-        .background(Color.white.opacity(0.08))
+        .background(AppColors.controlBackground)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
     

--- a/Pulse/Components/WebsiteView/EmptyWebsiteView.swift
+++ b/Pulse/Components/WebsiteView/EmptyWebsiteView.swift
@@ -16,6 +16,12 @@ struct EmptyWebsiteView: View {
                 .blendMode(.overlay)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .clipShape(RoundedRectangle(cornerRadius: { 
+            if #available(macOS 26.0, *) {
+                return 12
+            } else {
+                return 6
+            }
+        }()))
     }
 }

--- a/Pulse/Components/WebsiteView/WebsiteView.swift
+++ b/Pulse/Components/WebsiteView/WebsiteView.swift
@@ -19,7 +19,13 @@ struct WebsiteView: View {
                     .id(currentTab.id)  // This is crucial!
                     .background(Color(nsColor: .windowBackgroundColor))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .clipShape(RoundedRectangle(cornerRadius: { 
+                        if #available(macOS 26.0, *) {
+                            return 12
+                        } else {
+                            return 6
+                        }
+                    }()))
             } else {
                 EmptyWebsiteView()
             }

--- a/Pulse/Components/WebsiteView/WebsiteView.swift
+++ b/Pulse/Components/WebsiteView/WebsiteView.swift
@@ -17,6 +17,7 @@ struct WebsiteView: View {
                 // Add .id() modifier to force view recreation when tab changes
                 TabWebViewWrapper(tab: currentTab)
                     .id(currentTab.id)  // This is crucial!
+                    .background(Color(nsColor: .windowBackgroundColor))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipShape(RoundedRectangle(cornerRadius: 6))
             } else {

--- a/Pulse/Managers/BrowserManager/BrowserManager.swift
+++ b/Pulse/Managers/BrowserManager/BrowserManager.swift
@@ -33,6 +33,9 @@ class BrowserManager: ObservableObject {
     func updateSidebarWidth(_ width: CGFloat) {
         sidebarWidth = width
         savedSidebarWidth = width
+    }
+    
+    func saveSidebarWidthToDefaults() {
         saveSidebarSettings()
     }
 

--- a/Pulse/PulseApp.swift
+++ b/Pulse/PulseApp.swift
@@ -83,6 +83,7 @@ struct BackgroundWindowModifier: NSViewRepresentable {
             if let window = view.window {
                 window.toolbar?.isVisible = false
                 window.titlebarAppearsTransparent = true
+                window.backgroundColor = .clear
                 window.titleVisibility = .hidden
                 window.isReleasedWhenClosed = false
                 window.isMovableByWindowBackground = false

--- a/Pulse/Utils/Colors.swift
+++ b/Pulse/Utils/Colors.swift
@@ -1,0 +1,42 @@
+
+import SwiftUI
+
+struct AppColors {
+    static let textPrimary = Color(nsColor: .labelColor)
+    static let textSecondary = Color(nsColor: .secondaryLabelColor)
+    static let textTertiary = Color(nsColor: .tertiaryLabelColor)
+    static let textQuaternary = Color(nsColor: .quaternaryLabelColor)
+
+    static let background = Color(nsColor: .windowBackgroundColor)
+    static let backgroundSecondary = Color(nsColor: .underPageBackgroundColor)
+    
+    static let controlBackground = Color(nsColor: .controlBackgroundColor)
+    static let controlBackgroundHover = Color(nsColor: .controlColor)
+    static let controlBackgroundActive = Color(nsColor: .selectedContentBackgroundColor)
+}
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3:
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}


### PR DESCRIPTION
- Fixed sidebar jitter, ensured that websiteview won't draw clear background underneath web content (save battery + gpu).
- Added liquid glass background for macOS 26, updated corner radii for macOS 26 build as well
- added Colors.swift with hacky hex code handler for future color changes/tweaks